### PR TITLE
Refactor docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,20 +10,18 @@ RUN apt-get update && \
 # Install yarn globally
 RUN npm install -g yarn
 
-# Clone the repository
-RUN git clone https://github.com/hppanpaliya/React-TrashMail
+# Install pm2 globally
+RUN npm install -g pm2
 
-# Install dependencies for the React project
+# Copy in package.json files and run install to allow docker to cache themc
+COPY react/package.json /React-TrashMail/react/
 WORKDIR /React-TrashMail/react
 RUN yarn
-
-
-# Install dependencies for the mailserver
+COPY mailserver/package.json /React-TrashMail/mailserver/
 WORKDIR /React-TrashMail/mailserver
 RUN yarn
 
-# Install pm2 globally
-RUN npm install -g pm2
+COPY . /React-TrashMail
 
 # Define mountable volume
 VOLUME ["/React-TrashMail/mailserver/attachments"]

--- a/docker_start.sh
+++ b/docker_start.sh
@@ -25,4 +25,4 @@ fi
 
 # Start the application
 cd /React-TrashMail/mailserver
-pm2-runtime start yarn -- start
+pm2-runtime start yarn -- start:docker

--- a/docker_start.sh
+++ b/docker_start.sh
@@ -25,4 +25,4 @@ fi
 
 # Start the application
 cd /React-TrashMail/mailserver
-pm2-runtime start yarn -- start:docker
+PM2_HOME=/React-Trashmail/mailserver pm2-runtime start yarn -- start:docker

--- a/mailserver/package.json
+++ b/mailserver/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "nodemon server.js",
+    "start:docker": "node server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],


### PR DESCRIPTION
- Use local checkout instead of pulling from git during build 
- Rearrange yarn installs and package.json copies to make more efficient docker layers.
  - Separate the node module installs into their own layers. They're less likely to change vs the rest of the node code.
  - This means multiple builds that don't change the dependencies don't need to reinstall the modules
- Don't use nodemon inside the docker container
  - It doesn't really make sense since the files don't change in a built container
  - This also resolves a fun issue I had with lots of attachments causing the container to run out of inotify watches
- Set PM2_HOME value
  - Otherwise it defaults to HOME which in this case is /data/db. If the mongo db directory is mounted externally and that mount doesn't support socket files (Thanks Azure Container Instances /s) it blows up as pm2 uses socket files