### PR TITLE
Fix Docker image build (yarn setup + truncated util file)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
 # Use a lightweight Node base image (no Mongo bundled)
 FROM node:20-bullseye-slim
 
-# Install system deps (curl, git) and yarn/pm2
+# The node:20-bullseye-slim base already ships Node 20 and yarn.
+# Install curl (used by healthcheck) + git, and pm2 for process management.
 RUN set -eux; \
     apt-get update; \
-    apt-get install -y --no-install-recommends curl gnupg git ca-certificates; \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash -; \
-    apt-get install -y --no-install-recommends nodejs; \
-    npm install -g yarn; \
+    apt-get install -y --no-install-recommends curl git ca-certificates; \
     yarn global add pm2; \
     apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,13 +1,11 @@
 # Use a lightweight Node base image (no Mongo bundled)
 FROM node:20-bullseye-slim
 
-# Install OS deps + Node.js + yarn/pm2 in fewer layers
+# The node:20-bullseye-slim base already ships Node 20 and yarn.
+# Install curl (used by healthcheck) + git, and pm2 for process management.
 RUN set -eux; \
     apt-get update; \
-    apt-get install -y --no-install-recommends curl gnupg git ca-certificates; \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash -; \
-    apt-get install -y --no-install-recommends nodejs; \
-    npm install -g yarn; \
+    apt-get install -y --no-install-recommends curl git ca-certificates; \
     yarn global add pm2; \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/react/src/utils/recentInboxes.js
+++ b/react/src/utils/recentInboxes.js
@@ -25,3 +25,4 @@ export const addRecentInbox = (emailId) => {
   } catch {
     // storage full/unavailable — non-fatal
   }
+};


### PR DESCRIPTION
Fixes the two failures in the **Build React App and Docker Image (Native AMD64 + ARM64)** workflow on `main`.

### 1. Dockerfile setup layer — `EEXIST: /usr/local/bin/yarn`
Both `Dockerfile` and `Dockerfile.prod` reinstalled Node via nodesource and ran `npm install -g yarn`. The `node:20-bullseye-slim` base image **already ships Node 20 and yarn**, so the install collided:
```
npm error EEXIST: file already exists
npm error File exists: /usr/local/bin/yarn
```
Now the setup layer relies on the base image's Node + yarn and only installs `curl` (needed by `healthcheck.sh`), `git`, and `pm2`.

### 2. `vite build` — `Expected '}', got '<eof>'`
One of the automated **"Potential fix for pull request finding"** commits (234302d) wrapped the `lastEmailId` write in `recentInboxes.js` in a try/catch but dropped the arrow function's closing brace, truncating the file. Restored the closing `};`. (The autofix's try/catch intent is kept.)

### Validation
- Full local `docker build .` now completes end-to-end: setup layer → `yarn install --frozen-lockfile` (react + mailserver) → `vite build` (2302 modules) → copy into `mailserver/src/build` → image.
- Backend suite: **100/100** passing.
- The other three autofix-touched files (`config/index.js`, `AttachmentItem.jsx`, `useGlobalShortcuts.js`) were checked and are intact — only `recentInboxes.js` was damaged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)